### PR TITLE
Minor fixes to viewer docker compose

### DIFF
--- a/compose/viewer/docker-compose.wayland.yml
+++ b/compose/viewer/docker-compose.wayland.yml
@@ -4,8 +4,7 @@ networks:
     external: true
 services:
   nbs-viewer:
-    #image: ghcr.io/xraygui/nbs-pods/nbs-viewer:latest
-    image: nbs_viewer:latest
+    image: ghcr.io/xraygui/nbs-pods/nbs-viewer:latest
     volumes:
       - /run/user/${HOST_UID}:/run/user/${HOST_UID}
     devices:

--- a/compose/viewer/docker-compose.x11.yml
+++ b/compose/viewer/docker-compose.x11.yml
@@ -11,6 +11,6 @@ services:
       - DISPLAY=${DISPLAY}
       - QT_QPA_PLATFORM=xcb
       - IPYTHONDIR=/usr/local/share/ipython
-    command: nbs-viewer
+    command: nbs-viewer -f "/usr/local/share/ipython/profile_default/startup/viewer_config.toml"
     networks:
       - bluesky-services_bluesky


### PR DESCRIPTION
Fixed nbs-viewer command to use config file
wayland docker-compose switched back to use ghcr image